### PR TITLE
Feature: Normalize

### DIFF
--- a/src/continuity/transforms/__init__.py
+++ b/src/continuity/transforms/__init__.py
@@ -1,9 +1,14 @@
+from typing import TypeAlias
+
 from .transform import Transform
 from .compose import Compose
 from .scaling import ZNormalization
+
+Standardization: TypeAlias = ZNormalization
 
 __all__ = [
     "Transform",
     "Compose",
     "ZNormalization",
+    "Standardization",
 ]

--- a/src/continuity/transforms/__init__.py
+++ b/src/continuity/transforms/__init__.py
@@ -1,9 +1,9 @@
 from .transform import Transform
 from .compose import Compose
-from .scaling import Normalization
+from .scaling import Normalize
 
 __all__ = [
     "Transform",
     "Compose",
-    "Normalization",
+    "Normalize",
 ]

--- a/src/continuity/transforms/__init__.py
+++ b/src/continuity/transforms/__init__.py
@@ -1,13 +1,9 @@
 from .transform import Transform
 from .compose import Compose
-from .scaling import ZNormalization
-
-# aliases
-Standardization = ZNormalization
+from .scaling import Normalization
 
 __all__ = [
     "Transform",
     "Compose",
-    "ZNormalization",
-    "Standardization",
+    "Normalization",
 ]

--- a/src/continuity/transforms/__init__.py
+++ b/src/continuity/transforms/__init__.py
@@ -1,7 +1,9 @@
 from .transform import Transform
 from .compose import Compose
+from .scaling import ZNormalization
 
 __all__ = [
     "Transform",
     "Compose",
+    "ZNormalization",
 ]

--- a/src/continuity/transforms/__init__.py
+++ b/src/continuity/transforms/__init__.py
@@ -1,10 +1,9 @@
-from typing import TypeAlias
-
 from .transform import Transform
 from .compose import Compose
 from .scaling import ZNormalization
 
-Standardization: TypeAlias = ZNormalization
+# aliases
+Standardization = ZNormalization
 
 __all__ = [
     "Transform",

--- a/src/continuity/transforms/scaling.py
+++ b/src/continuity/transforms/scaling.py
@@ -4,7 +4,7 @@ import warnings
 from .transform import Transform
 
 
-class Normalization(Transform):
+class Normalize(Transform):
     r"""Z-normalization transformation.
 
     This transformation uses the mean $\mu$ and the standard deviation $\sigma$ passed in the initialization and scales

--- a/src/continuity/transforms/scaling.py
+++ b/src/continuity/transforms/scaling.py
@@ -4,11 +4,11 @@ import warnings
 from .transform import Transform
 
 
-class ZNormalization(Transform):
+class Normalization(Transform):
     r"""Z-normalization transformation.
 
-    This transformation takes the mean $\mu$ and the standard deviation $\sigma$ of the tensor and scales it
-    with $z(x)=\frac{x - \mu}{\sigma}$.
+    This transformation uses the mean $\mu$ and the standard deviation $\sigma$ passed in the initialization and scales
+    tensors $x$ with the mapping $z(x)=\frac{x - \mu}{\sigma}$.
 
     Attributes:
         mean: mean value of the tensor.
@@ -25,9 +25,9 @@ class ZNormalization(Transform):
         """
 
         Args:
-            mean: mean of the tensor that should be scaled. To scale a (100, 40, 3) tensor along the last
+            mean: mean used to scale tensors in forward. To scale a (100, 40, 3) tensor along the last
             dimension, provide the mean along the last dimension in the shape (1, 1, 3).
-            std: standard deviation of the tensor that should be scaled. Should have the same shape as the mean.
+            std: standard deviation used to scale tensors in forward. Should have the same shape as the mean.
             epsilon: Value for numerical stability (to prevent divide by zero).
         """
         assert mean.shape == std.shape

--- a/src/continuity/transforms/scaling.py
+++ b/src/continuity/transforms/scaling.py
@@ -11,8 +11,8 @@ class Normalize(Transform):
     tensors $x$ with the mapping $z(x)=\frac{x - \mu}{\sigma}$.
 
     Attributes:
-        mean: mean value of the tensor.
-        std: standard deviation of the tensor.
+        mean: mean value used to scale tensors.
+        std: standard deviation used to scale tensors.
         epsilon: Value to prevent divide by zero.
     """
 
@@ -25,12 +25,10 @@ class Normalize(Transform):
         """
 
         Args:
-            mean: mean used to scale tensors in forward. To scale a (100, 40, 3) tensor along the last
-            dimension, provide the mean along the last dimension in the shape (1, 1, 3).
-            std: standard deviation used to scale tensors in forward. Should have the same shape as the mean.
+            mean: mean used to scale tensors.
+            std: standard deviation used to scale tensors in forward.
             epsilon: Value for numerical stability (to prevent divide by zero).
         """
-        assert mean.shape == std.shape
         assert torch.all(torch.greater_equal(std, torch.zeros(std.shape)))
         super().__init__()
         self.mean = mean
@@ -47,16 +45,23 @@ class Normalize(Transform):
             self.epsilon = epsilon
 
     def forward(self, tensor: torch.Tensor) -> torch.Tensor:
-        r"""
-        $$\frac{x - \mu}{\sigma}$$
+        r"""Applies normalization to the input tensor.
 
         Args:
             tensor: input.
 
         Returns:
-            Z-normalized tensor.
+            normalized tensor.
         """
         return (tensor - self.mean) / (self.std + self.epsilon)
 
-    def backward(self, tensor: torch.Tensor) -> torch.Tensor:
+    def undo(self, tensor: torch.Tensor) -> torch.Tensor:
+        r"""Reverse the normalization.
+
+        Args:
+            tensor: normalized tensor.
+
+        Returns:
+            tensor with normalization undone.
+        """
         return tensor * (self.std + self.epsilon) + self.mean

--- a/src/continuity/transforms/scaling.py
+++ b/src/continuity/transforms/scaling.py
@@ -1,0 +1,62 @@
+import torch
+import warnings
+
+from .transform import Transform
+
+
+class ZNormalization(Transform):
+    r"""Z-normalization transformation.
+
+    This transformation takes the mean $\mu$ and the standard deviation $\sigma$ of the tensor and scales it
+    with $z(x)=\frac{x - \mu}{\sigma}$.
+
+    Attributes:
+        mean: mean value of the tensor.
+        std: standard deviation of the tensor.
+        epsilon: Value to prevent divide by zero.
+    """
+
+    def __init__(
+        self,
+        mean: torch.Tensor,
+        std: torch.Tensor,
+        epsilon: float = None,
+    ):
+        """
+
+        Args:
+            mean: mean of the tensor that should be scaled. To scale a (100, 40, 3) tensor along the last
+            dimension, provide the mean along the last dimension in the shape (1, 1, 3).
+            std: standard deviation of the tensor that should be scaled. Should have the same shape as the mean.
+            epsilon: Value for numerical stability (to prevent divide by zero).
+        """
+        assert mean.shape == std.shape
+        assert torch.all(torch.greater_equal(std, torch.zeros(std.shape)))
+        super().__init__()
+        self.mean = mean
+        if torch.allclose(std, torch.zeros(std.shape)):
+            warnings.warn(
+                "Z-normalization with standard deviation 0! "
+                "The feature vector does not have any discriminative power!",
+                stacklevel=2,
+            )
+        self.std = std
+        if epsilon is None:
+            self.epsilon = torch.finfo(torch.get_default_dtype()).tiny
+        else:
+            self.epsilon = epsilon
+
+    def forward(self, tensor: torch.Tensor) -> torch.Tensor:
+        r"""
+        $$\frac{x - \mu}{\sigma}$$
+
+        Args:
+            tensor: input.
+
+        Returns:
+            Z-normalized tensor.
+        """
+        return (tensor - self.mean) / (self.std + self.epsilon)
+
+    def backward(self, tensor: torch.Tensor) -> torch.Tensor:
+        return tensor * (self.std + self.epsilon) + self.mean

--- a/tests/transforms/test_scaling.py
+++ b/tests/transforms/test_scaling.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from continuity.transforms import ZNormalization
+from continuity.transforms import ZNormalization, Standardization
 
 
 def test_z_norm_zero():
@@ -67,3 +67,7 @@ def test_z_norm_singular():
     t = torch.rand((100, 3))
 
     assert not torch.any(torch.isnan(tf(t)))
+
+
+def test_z_norm_alias():
+    assert Standardization == ZNormalization

--- a/tests/transforms/test_scaling.py
+++ b/tests/transforms/test_scaling.py
@@ -87,5 +87,5 @@ def test_normalization_undo(random_normalization_set):
     tf, t = random_normalization_set
 
     t_normalized = tf(t)
-    # higher tolerance required because of epsilon (introduced for numerical stability).
-    assert torch.allclose(tf.undo(t_normalized), t, atol=1e-7)
+    # higher tolerance required because of numerical accuracy of these operations.
+    assert torch.allclose(tf.undo(t_normalized), t)

--- a/tests/transforms/test_scaling.py
+++ b/tests/transforms/test_scaling.py
@@ -3,6 +3,9 @@ import torch
 
 from continuity.transforms import Normalize
 
+# Set random seed for reproducibility
+torch.manual_seed(0)
+
 
 @pytest.fixture(scope="module")
 def random_normalization_set():
@@ -69,8 +72,7 @@ def test_normalization_correct():
 def test_normalization_singular():
     mean = torch.zeros((1, 3))
     std = torch.zeros((1, 3))
-    with pytest.warns(UserWarning):
-        tf = Normalize(mean=mean, std=std)
+    tf = Normalize(mean=mean, std=std)
 
     t = torch.rand((100, 3))
     tf_t = tf(t)
@@ -88,5 +90,7 @@ def test_normalization_undo(random_normalization_set):
     tf, t = random_normalization_set
 
     t_normalized = tf(t)
-    # higher tolerance required because of numerical accuracy of these operations.
-    assert torch.allclose(tf.undo(t_normalized), t, atol=1e-7)
+    t2 = tf.undo(t_normalized)
+
+    # higher tolerance required because of numerical accuracy of these operations
+    assert torch.allclose(t, t2, atol=1e-7)

--- a/tests/transforms/test_scaling.py
+++ b/tests/transforms/test_scaling.py
@@ -1,0 +1,56 @@
+import torch
+
+from continuity.transforms import ZNormalization
+
+
+def test_z_norm_zero():
+    mean = torch.zeros((1, 3))
+    std = torch.rand((1, 3))
+
+    tf = ZNormalization(mean=mean, std=std)
+
+    assert torch.allclose(tf(torch.zeros(100, 3)), torch.zeros(100, 3))
+
+
+def test_z_norm_unchanged():
+    mean = torch.zeros((1, 3))
+    std = torch.ones((1, 3))
+    tf = ZNormalization(mean=mean, std=std)
+
+    t = torch.rand((100, 3))
+
+    assert torch.allclose(tf(t), t)
+
+
+def test_z_norm_mean():
+    mean = torch.ones((1, 3))
+    std = torch.ones((1, 3))
+    tf = ZNormalization(mean=mean, std=std)
+
+    t = torch.rand((100, 3))
+    assert torch.allclose(tf(t), t - 1.0)
+
+
+def test_z_norm_std():
+    factor = 2.0
+    mean = torch.zeros((1, 3))
+    std = factor * torch.ones((1, 3))
+    tf = ZNormalization(mean=mean, std=std)
+
+    t = torch.rand((100, 3))
+    assert torch.allclose(tf(t), t / factor)
+
+
+def test_z_norm_correct():
+    t = torch.tensor([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]).to(
+        torch.get_default_dtype()
+    )
+    mean = torch.mean(t)
+    std = torch.std(
+        t, correction=0
+    )  # correction as otherwise it defaults to Bessel's correction
+    assert mean == 5.0
+    assert std == 2.0
+    tf = ZNormalization(mean, std)
+
+    assert torch.allclose(tf(t), (t - 5.0) / 2.0)

--- a/tests/transforms/test_scaling.py
+++ b/tests/transforms/test_scaling.py
@@ -69,13 +69,13 @@ def test_normalization_correct():
 def test_normalization_singular():
     mean = torch.zeros((1, 3))
     std = torch.zeros((1, 3))
-    with pytest.warns(UserWarning) as record:
-        tf = Normalize(mean=mean, std=std)
-    assert len(record) == 1
+    tf = Normalize(mean=mean, std=std)
 
     t = torch.rand((100, 3))
+    tf_t = tf(t)
 
-    assert not torch.any(torch.isnan(tf(t)))
+    assert not torch.any(torch.isnan(tf_t))
+    assert not torch.any(torch.isinf(tf_t))
 
 
 def test_normalization_dimensions(random_normalization_set):

--- a/tests/transforms/test_scaling.py
+++ b/tests/transforms/test_scaling.py
@@ -1,48 +1,48 @@
 import pytest
 import torch
 
-from continuity.transforms import ZNormalization, Standardization
+from continuity.transforms import Normalization
 
 
-def test_z_norm_zero():
+def test_normalization_zero():
     mean = torch.zeros((1, 3))
     std = torch.rand((1, 3))
 
-    tf = ZNormalization(mean=mean, std=std)
+    tf = Normalization(mean=mean, std=std)
 
     assert torch.allclose(tf(torch.zeros(100, 3)), torch.zeros(100, 3))
 
 
-def test_z_norm_unchanged():
+def test_normalization_unchanged():
     mean = torch.zeros((1, 3))
     std = torch.ones((1, 3))
-    tf = ZNormalization(mean=mean, std=std)
+    tf = Normalization(mean=mean, std=std)
 
     t = torch.rand((100, 3))
 
     assert torch.allclose(tf(t), t)
 
 
-def test_z_norm_mean():
+def test_normalization_mean():
     mean = torch.ones((1, 3))
     std = torch.ones((1, 3))
-    tf = ZNormalization(mean=mean, std=std)
+    tf = Normalization(mean=mean, std=std)
 
     t = torch.rand((100, 3))
     assert torch.allclose(tf(t), t - 1.0)
 
 
-def test_z_norm_std():
+def test_normalization_std():
     factor = 2.0
     mean = torch.zeros((1, 3))
     std = factor * torch.ones((1, 3))
-    tf = ZNormalization(mean=mean, std=std)
+    tf = Normalization(mean=mean, std=std)
 
     t = torch.rand((100, 3))
     assert torch.allclose(tf(t), t / factor)
 
 
-def test_z_norm_correct():
+def test_normalization_correct():
     t = torch.tensor([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]).to(
         torch.get_default_dtype()
     )
@@ -52,22 +52,18 @@ def test_z_norm_correct():
     )  # correction as otherwise it defaults to Bessel's correction
     assert mean == 5.0
     assert std == 2.0
-    tf = ZNormalization(mean, std)
+    tf = Normalization(mean, std)
 
     assert torch.allclose(tf(t), (t - 5.0) / 2.0)
 
 
-def test_z_norm_singular():
+def test_normalization_singular():
     mean = torch.zeros((1, 3))
     std = torch.zeros((1, 3))
     with pytest.warns(UserWarning) as record:
-        tf = ZNormalization(mean=mean, std=std)
+        tf = Normalization(mean=mean, std=std)
     assert len(record) == 1
 
     t = torch.rand((100, 3))
 
     assert not torch.any(torch.isnan(tf(t)))
-
-
-def test_z_norm_alias():
-    assert Standardization == ZNormalization

--- a/tests/transforms/test_scaling.py
+++ b/tests/transforms/test_scaling.py
@@ -75,3 +75,11 @@ def test_normalization_dimensions():
     tf = Normalization(mean=mean, std=std)
     t = torch.rand((100, 3, 15, 7))
     assert tf(t).shape == t.shape
+
+
+def test_normalization_other_dimensions():
+    mean = torch.rand((1, 1, 15, 7))
+    std = torch.rand((1, 1, 15, 7))
+    tf = Normalization(mean=mean, std=std)
+    t = torch.rand((100, 3, 15, 7))
+    assert tf(t).shape == t.shape

--- a/tests/transforms/test_scaling.py
+++ b/tests/transforms/test_scaling.py
@@ -1,14 +1,14 @@
 import pytest
 import torch
 
-from continuity.transforms import Normalization
+from continuity.transforms import Normalize
 
 
 def test_normalization_zero():
     mean = torch.zeros((1, 3))
     std = torch.rand((1, 3))
 
-    tf = Normalization(mean=mean, std=std)
+    tf = Normalize(mean=mean, std=std)
 
     assert torch.allclose(tf(torch.zeros(100, 3)), torch.zeros(100, 3))
 
@@ -16,7 +16,7 @@ def test_normalization_zero():
 def test_normalization_unchanged():
     mean = torch.zeros((1, 3))
     std = torch.ones((1, 3))
-    tf = Normalization(mean=mean, std=std)
+    tf = Normalize(mean=mean, std=std)
 
     t = torch.rand((100, 3))
 
@@ -26,7 +26,7 @@ def test_normalization_unchanged():
 def test_normalization_mean():
     mean = torch.ones((1, 3))
     std = torch.ones((1, 3))
-    tf = Normalization(mean=mean, std=std)
+    tf = Normalize(mean=mean, std=std)
 
     t = torch.rand((100, 3))
     assert torch.allclose(tf(t), t - 1.0)
@@ -36,7 +36,7 @@ def test_normalization_std():
     factor = 2.0
     mean = torch.zeros((1, 3))
     std = factor * torch.ones((1, 3))
-    tf = Normalization(mean=mean, std=std)
+    tf = Normalize(mean=mean, std=std)
 
     t = torch.rand((100, 3))
     assert torch.allclose(tf(t), t / factor)
@@ -52,7 +52,7 @@ def test_normalization_correct():
     )  # correction as otherwise it defaults to Bessel's correction
     assert mean == 5.0
     assert std == 2.0
-    tf = Normalization(mean, std)
+    tf = Normalize(mean, std)
 
     assert torch.allclose(tf(t), (t - 5.0) / 2.0)
 
@@ -61,7 +61,7 @@ def test_normalization_singular():
     mean = torch.zeros((1, 3))
     std = torch.zeros((1, 3))
     with pytest.warns(UserWarning) as record:
-        tf = Normalization(mean=mean, std=std)
+        tf = Normalize(mean=mean, std=std)
     assert len(record) == 1
 
     t = torch.rand((100, 3))
@@ -72,7 +72,7 @@ def test_normalization_singular():
 def test_normalization_dimensions():
     mean = torch.rand((1, 1, 1, 7))
     std = torch.rand((1, 1, 1, 7))
-    tf = Normalization(mean=mean, std=std)
+    tf = Normalize(mean=mean, std=std)
     t = torch.rand((100, 3, 15, 7))
     assert tf(t).shape == t.shape
 
@@ -80,6 +80,6 @@ def test_normalization_dimensions():
 def test_normalization_other_dimensions():
     mean = torch.rand((1, 1, 15, 7))
     std = torch.rand((1, 1, 15, 7))
-    tf = Normalization(mean=mean, std=std)
+    tf = Normalize(mean=mean, std=std)
     t = torch.rand((100, 3, 15, 7))
     assert tf(t).shape == t.shape

--- a/tests/transforms/test_scaling.py
+++ b/tests/transforms/test_scaling.py
@@ -69,7 +69,8 @@ def test_normalization_correct():
 def test_normalization_singular():
     mean = torch.zeros((1, 3))
     std = torch.zeros((1, 3))
-    tf = Normalize(mean=mean, std=std)
+    with pytest.warns(UserWarning):
+        tf = Normalize(mean=mean, std=std)
 
     t = torch.rand((100, 3))
     tf_t = tf(t)
@@ -88,4 +89,4 @@ def test_normalization_undo(random_normalization_set):
 
     t_normalized = tf(t)
     # higher tolerance required because of numerical accuracy of these operations.
-    assert torch.allclose(tf.undo(t_normalized), t)
+    assert torch.allclose(tf.undo(t_normalized), t, atol=1e-7)

--- a/tests/transforms/test_scaling.py
+++ b/tests/transforms/test_scaling.py
@@ -87,4 +87,5 @@ def test_normalization_undo(random_normalization_set):
     tf, t = random_normalization_set
 
     t_normalized = tf(t)
-    assert torch.allclose(tf.undo(t_normalized), t)
+    # higher tolerance required because of epsilon (introduced for numerical stability).
+    assert torch.allclose(tf.undo(t_normalized), t, atol=1e-7)

--- a/tests/transforms/test_scaling.py
+++ b/tests/transforms/test_scaling.py
@@ -67,3 +67,11 @@ def test_normalization_singular():
     t = torch.rand((100, 3))
 
     assert not torch.any(torch.isnan(tf(t)))
+
+
+def test_normalization_dimensions():
+    mean = torch.rand((1, 1, 1, 7))
+    std = torch.rand((1, 1, 1, 7))
+    tf = Normalization(mean=mean, std=std)
+    t = torch.rand((100, 3, 15, 7))
+    assert tf(t).shape == t.shape

--- a/tests/transforms/test_scaling.py
+++ b/tests/transforms/test_scaling.py
@@ -4,6 +4,15 @@ import torch
 from continuity.transforms import Normalize
 
 
+@pytest.fixture(scope="module")
+def random_normalization_set():
+    mean = torch.rand((1, 1, 15, 7))
+    std = torch.rand((1, 1, 15, 7))
+    tf = Normalize(mean=mean, std=std)
+    t = torch.rand((100, 3, 15, 7))
+    return tf, t
+
+
 def test_normalization_zero():
     mean = torch.zeros((1, 3))
     std = torch.rand((1, 3))
@@ -69,17 +78,13 @@ def test_normalization_singular():
     assert not torch.any(torch.isnan(tf(t)))
 
 
-def test_normalization_dimensions():
-    mean = torch.rand((1, 1, 1, 7))
-    std = torch.rand((1, 1, 1, 7))
-    tf = Normalize(mean=mean, std=std)
-    t = torch.rand((100, 3, 15, 7))
+def test_normalization_dimensions(random_normalization_set):
+    tf, t = random_normalization_set
     assert tf(t).shape == t.shape
 
 
-def test_normalization_other_dimensions():
-    mean = torch.rand((1, 1, 15, 7))
-    std = torch.rand((1, 1, 15, 7))
-    tf = Normalize(mean=mean, std=std)
-    t = torch.rand((100, 3, 15, 7))
-    assert tf(t).shape == t.shape
+def test_normalization_undo(random_normalization_set):
+    tf, t = random_normalization_set
+
+    t_normalized = tf(t)
+    assert torch.allclose(tf.undo(t_normalized), t)

--- a/tests/transforms/test_scaling.py
+++ b/tests/transforms/test_scaling.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from continuity.transforms import ZNormalization
@@ -54,3 +55,15 @@ def test_z_norm_correct():
     tf = ZNormalization(mean, std)
 
     assert torch.allclose(tf(t), (t - 5.0) / 2.0)
+
+
+def test_z_norm_singular():
+    mean = torch.zeros((1, 3))
+    std = torch.zeros((1, 3))
+    with pytest.warns(UserWarning) as record:
+        tf = ZNormalization(mean=mean, std=std)
+    assert len(record) == 1
+
+    t = torch.rand((100, 3))
+
+    assert not torch.any(torch.isnan(tf(t)))


### PR DESCRIPTION
# Feature: Normalize

## Description

This pull request introduces a new feature for data preprocessing: Z-Normalization. Z-Normalization, also known as standardization, is a technique used to scale data so that it has a mean of 0 and a standard deviation of 1. This process is essential in many machine learning algorithms as it ensures that each feature contributes equally to the analysis, improving the performance and stability of the models.

### Which issue does this PR tackle?

  - Addresses the need for a standardized data preprocessing step in our machine learning pipeline. The lack of a z-normalization feature has been a significant gap in our data preprocessing capabilities, leading to suboptimal performance in models sensitive to the scale of data.

### How does it solve the problem?

  - Implements Z-normalization.
  - Offers alias `Standardization`.
  - Offering compatibility with multi-dimensional tensors.

### How are the changes tested?

- Added unit tests:
  - 4 tests against trivial examples.
  - 1 test with common 8 students set.
  - 1 test testing for singularity.
  - 1 test assuring the alias is set correctly
  - 2 tests with higher dimensional data and multiple scaling dimensions


## Checklist for Contributors

- [x] Scope: This PR tackles exactly one problem.
- [x] Conventions: The branch follows the `feature/title-slug` convention.
- [x] Conventions: The PR title follows the `Bugfix: Title` convention.
- [x] Coding style: The code passes all pre-commit hooks.
- [x] Documentation: All changes are well-documented.
- [x] Tests: New features are tested and all tests pass successfully.
- [x] Changelog: Updated CHANGELOG.md for new features or breaking changes.
- [x] Review: A suitable reviewer has been assigned.


## Checklist for Reviewers:

- [x] The PR solves the issue it claims to solve and only this one.
- [x] Changes are tested sufficiently and all tests pass.
- [x] Documentation is complete and well-written.
- [x] Changelog has been updated, if necessary.
