### PR TITLE
Add activation function after first layer

### DIFF
--- a/src/continuity/operators/common.py
+++ b/src/continuity/operators/common.py
@@ -75,18 +75,20 @@ class DeepResidualNetwork(torch.nn.Module):
         depth: int,
         act: Optional[torch.nn.Module] = None,
     ):
+        assert depth >= 1, "DeepResidualNetwork has at least depth 1."
         super().__init__()
 
         self.act = act or torch.nn.Tanh()
         self.first_layer = torch.nn.Linear(input_size, width)
         self.hidden_layers = torch.nn.ModuleList(
-            [ResidualLayer(width, act=self.act) for _ in range(depth)]
+            [ResidualLayer(width, act=self.act) for _ in range(1, depth)]
         )
         self.last_layer = torch.nn.Linear(width, output_size)
 
     def forward(self, x):
         """Forward pass."""
         x = self.first_layer(x)
+        x = self.act(x)
         for layer in self.hidden_layers:
             x = layer(x)
         return self.last_layer(x)


### PR DESCRIPTION
# Bugfix: Add activation function after first layer

## Description

No activation function was applied after the first layer in the residual network. Also, the actual width of a network was given by width+1. Now, it correctly correspond to the width parameter.

To make the test scripts consistent to previous tests, the widths had to be adjusted by +1. Without this fix, the tests failed


## Checklist for Contributors

- [ ] Scope: This PR tackles exactly one problem.
- [ ] Conventions: The branch follows the `feature/title-slug` convention.
- [ ] Conventions: The PR title follows the `Bugfix: Title` convention.
- [ ] Coding style: The code passes all pre-commit hooks.
- [ ] Documentation: All changes are well-documented.
- [ ] Tests: New features are tested and all tests pass successfully.
- [ ] Changelog: Updated CHANGELOG.md for new features or breaking changes.
- [ ] Review: A suitable reviewer has been assigned.


## Checklist for Reviewers:

- [ ] The PR solves the issue it claims to solve and only this one.
- [ ] Changes are tested sufficiently and all tests pass.
- [ ] Documentation is complete and well-written.
- [ ] Changelog has been updated, if necessary.
