### PR TITLE
Bugfix: RegularGridSampler input type

### DIFF
--- a/src/continuity/discrete/regular_grid.py
+++ b/src/continuity/discrete/regular_grid.py
@@ -5,6 +5,7 @@ Samplers sampling on a regular grid from n-dimensional boxes.
 """
 
 import torch
+from typing import Union
 
 from .box_sampler import BoxSampler
 
@@ -45,7 +46,10 @@ class RegularGridSampler(BoxSampler):
     """
 
     def __init__(
-        self, x_min: torch.Tensor, x_max: torch.Tensor, prefer_more_samples: bool = True
+        self,
+        x_min: Union[torch.Tensor, list],
+        x_max: Union[torch.Tensor, list],
+        prefer_more_samples: bool = True,
     ):
         super().__init__(x_min, x_max)
         self.prefer_more_samples = prefer_more_samples


### PR DESCRIPTION
# Bugfix: RegularGridSampler input type

## Description

This pr introduces the union typing also to the regular grid sampler.

### Which issue does this PR tackle?

  - `RegularGridSampler` currently expects only `torch.Tensor` types.

### How does it solve the problem?

  - Changes the input type to also accept lists.

### How are the changes tested?

  - Feature is already tested in the tests for the box-sampler.


## Checklist for Contributors

- [x] Scope: This PR tackles exactly one problem.
- [x] Conventions: The branch follows the `feature/title-slug` convention.
- [x] Conventions: The PR title follows the `Bugfix: Title` convention.
- [x] Coding style: The code passes all pre-commit hooks.
- [x] Documentation: All changes are well-documented.
- [x] Tests: New features are tested and all tests pass successfully.
- [x] Changelog: Updated CHANGELOG.md for new features or breaking changes.
- [x] Review: A suitable reviewer has been assigned.


## Checklist for Reviewers:

- [ ] The PR solves the issue it claims to solve and only this one.
- [ ] Changes are tested sufficiently and all tests pass.
- [ ] Documentation is complete and well-written.
- [ ] Changelog has been updated, if necessary.
