### PR TITLE
Cleanup: Generalize neural operator and introduce OperatorShapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Add `Benchmark` base class.
 - Add `SineBenchmark`.
 - Implement `DeepNeuralOperator`.
+- Generalize `NeuralOperator` to take a list of operators.
+- The `data.DatasetShapes` class becomes `operators.OperatorShapes` without `num_observations` attribute.
 
 ## 0.0.0 (2024-02-22)
 

--- a/examples/superresolution.ipynb
+++ b/examples/superresolution.ipynb
@@ -124,7 +124,7 @@
    "outputs": [],
    "source": [
     "# Fallback if flame data is not available (e.g. in CI)\n",
-    "from continuity.data.shape import DatasetShapes, TensorShape\n",
+    "from continuity.operators.shape import OperatorShapes, TensorShape\n",
     "\n",
     "flame_dir = pathlib.Path.cwd().joinpath(\"..\", \"data\", \"flame\")\n",
     "if not flame_dir.joinpath(\"flowfields\").is_dir():\n",
@@ -135,8 +135,7 @@
     "        y = torch.randn(N, 16384, 2)\n",
     "        v = torch.randn(N, 16384, 1)\n",
     "\n",
-    "        shapes = DatasetShapes(\n",
-    "            N,\n",
+    "        shapes = OperatorShapes(\n",
     "            x=TensorShape(256, 2),\n",
     "            u=TensorShape(256, 1),\n",
     "            y=TensorShape(16384, 2),\n",

--- a/examples/training.ipynb
+++ b/examples/training.ipynb
@@ -190,7 +190,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DatasetShapes(num_observations=128, x=TensorShape(num=32, dim=1), u=TensorShape(num=32, dim=1), y=TensorShape(num=32, dim=1), v=TensorShape(num=32, dim=1))\n"
+      "OperatorShapes(x=TensorShape(num=32, dim=1), u=TensorShape(num=32, dim=1), y=TensorShape(num=32, dim=1), v=TensorShape(num=32, dim=1))\n"
      ]
     }
    ],

--- a/src/continuity/data/__init__.py
+++ b/src/continuity/data/__init__.py
@@ -6,12 +6,10 @@ Every data set is a list of `(x, u, y, v)` tuples.
 """
 
 from .dataset import OperatorDataset
-from .shape import DatasetShapes
 from .utility import split, dataset_loss
 
 __all__ = [
     "OperatorDataset",
-    "DatasetShapes",
     "split",
     "dataset_loss",
 ]

--- a/src/continuity/data/dataset.py
+++ b/src/continuity/data/dataset.py
@@ -9,7 +9,7 @@ import torch
 import torch.utils.data as td
 from typing import Tuple
 
-from .shape import DatasetShapes, TensorShape
+from continuity.operators.shape import OperatorShapes, TensorShape
 
 
 class OperatorDataset(td.Dataset):
@@ -58,8 +58,7 @@ class OperatorDataset(td.Dataset):
         self.v = v
 
         # used to initialize architectures
-        self.shapes = DatasetShapes(
-            num_observations=int(x.size(0)),
+        self.shapes = OperatorShapes(
             x=TensorShape(*x.size()[1:]),
             u=TensorShape(*u.size()[1:]),
             y=TensorShape(*y.size()[1:]),
@@ -83,7 +82,7 @@ class OperatorDataset(td.Dataset):
         Returns:
             number of samples in the entire set.
         """
-        return self.shapes.num_observations
+        return self.x.size(0)
 
     def __getitem__(
         self, idx

--- a/src/continuity/operators/__init__.py
+++ b/src/continuity/operators/__init__.py
@@ -11,18 +11,18 @@ v = operator(x, u, y)
 ```
 """
 
-from .common import DeepResidualNetwork
 from .operator import Operator
 from .neuraloperator import NeuralOperator
 from .deeponet import DeepONet
 from .belnet import BelNet
 from .deep_neural_operator import DeepNeuralOperator
+from .shape import OperatorShapes
 
 __all__ = [
     "Operator",
+    "OperatorShapes",
     "DeepONet",
     "NeuralOperator",
-    "DeepResidualNetwork",
     "BelNet",
     "DeepNeuralOperator",
 ]

--- a/src/continuity/operators/belnet.py
+++ b/src/continuity/operators/belnet.py
@@ -8,7 +8,7 @@ import torch
 from typing import Optional
 from continuity.operators import Operator
 from continuity.operators.common import DeepResidualNetwork
-from continuity.data import DatasetShapes
+from continuity.operators.shape import OperatorShapes
 
 
 class BelNet(Operator):
@@ -28,7 +28,7 @@ class BelNet(Operator):
     expressive deep residual networks.
 
     Args:
-        shapes: Shape variable of the dataset
+        shapes: Shapes of the operator
         K: Number of basis functions
         N_1: Width of the projection basis network
         D_1: Depth of the projection basis network
@@ -41,7 +41,7 @@ class BelNet(Operator):
 
     def __init__(
         self,
-        shapes: DatasetShapes,
+        shapes: OperatorShapes,
         K: int = 4,
         N_1: int = 32,
         D_1: int = 1,

--- a/src/continuity/operators/deep_neural_operator.py
+++ b/src/continuity/operators/deep_neural_operator.py
@@ -8,7 +8,7 @@ import torch
 from typing import Optional
 from continuity.operators import Operator
 from continuity.operators.common import DeepResidualNetwork
-from continuity.data import DatasetShapes
+from continuity.operators.shape import OperatorShapes
 
 
 class DeepNeuralOperator(Operator):
@@ -17,7 +17,7 @@ class DeepNeuralOperator(Operator):
     input locations, input values, and the evaluation point as input for a deep residual network.
 
     Args:
-        shapes: An instance of `DatasetShapes`.
+        shapes: An instance of `OperatorShapes`.
         width: The width of the `DeepResidualNetwork`.
         depth: The depth of the `DeepResidualNetwork`.
         act: Activation function of the `DeepResidualNetwork`.
@@ -25,7 +25,7 @@ class DeepNeuralOperator(Operator):
 
     def __init__(
         self,
-        shapes: DatasetShapes,
+        shapes: OperatorShapes,
         width: int = 32,
         depth: int = 3,
         act: Optional[torch.nn.Module] = None,

--- a/src/continuity/operators/deeponet.py
+++ b/src/continuity/operators/deeponet.py
@@ -7,7 +7,7 @@ The DeepONet architecture.
 import torch
 from continuity.operators import Operator
 from continuity.operators.common import DeepResidualNetwork
-from continuity.data import DatasetShapes
+from continuity.operators.shape import OperatorShapes
 
 
 class DeepONet(Operator):
@@ -22,7 +22,7 @@ class DeepONet(Operator):
     the same positions.
 
     Args:
-        shapes: Shape variable of the dataset
+        shapes: Shapes of the operator.
         branch_width: Width of branch network
         branch_depth: Depth of branch network
         trunk_width: Width of trunk network
@@ -32,7 +32,7 @@ class DeepONet(Operator):
 
     def __init__(
         self,
-        shapes: DatasetShapes,
+        shapes: OperatorShapes,
         branch_width: int = 32,
         branch_depth: int = 3,
         trunk_width: int = 32,

--- a/src/continuity/operators/integralkernel.py
+++ b/src/continuity/operators/integralkernel.py
@@ -7,8 +7,9 @@ Integral kernel operations.
 import torch
 from abc import ABC, abstractmethod
 from typing import Optional
-from continuity.operators import Operator, DeepResidualNetwork
-from continuity.data import DatasetShapes
+from continuity.operators import Operator
+from continuity.operators.common import DeepResidualNetwork
+from continuity.operators.shape import OperatorShapes
 
 
 class Kernel(torch.nn.Module, ABC):
@@ -36,10 +37,10 @@ class Kernel(torch.nn.Module, ABC):
     ```
 
     Args:
-        shapes: Shapes of the dataset
+        shapes: Shapes of the operator.
     """
 
-    def __init__(self, shapes: DatasetShapes):
+    def __init__(self, shapes: OperatorShapes):
         super().__init__()
         self.shapes = shapes
 
@@ -63,7 +64,7 @@ class NeuralNetworkKernel(Kernel):
     by a simple feed forward neural network with skip connections.
 
     Args:
-        shapes: Shape variable of the dataset
+        shapes: Shapes of the operator
         kernel_width: Width of kernel network
         kernel_depth: Depth of kernel network
         act: Activation function
@@ -71,7 +72,7 @@ class NeuralNetworkKernel(Kernel):
 
     def __init__(
         self,
-        shapes: DatasetShapes,
+        shapes: OperatorShapes,
         kernel_width: int,
         kernel_depth: int,
         act: Optional[torch.nn.Module] = None,

--- a/src/continuity/operators/neuraloperator.py
+++ b/src/continuity/operators/neuraloperator.py
@@ -8,7 +8,7 @@ stack of continuous convolutions with a lifting layer and a projection layer.
 import torch
 from typing import List, Optional
 from continuity.operators import Operator
-from continuity.data import DatasetShapes
+from continuity.operators.shape import OperatorShapes
 
 
 class NeuralOperator(Operator):
@@ -31,7 +31,7 @@ class NeuralOperator(Operator):
 
     def __init__(
         self,
-        shapes: DatasetShapes,
+        shapes: OperatorShapes,
         layers: List[Operator],
         act: Optional[torch.nn.Module] = None,
     ):

--- a/src/continuity/operators/neuraloperator.py
+++ b/src/continuity/operators/neuraloperator.py
@@ -6,9 +6,9 @@ stack of continuous convolutions with a lifting layer and a projection layer.
 """
 
 import torch
+from typing import List, Optional
 from continuity.operators import Operator
 from continuity.data import DatasetShapes
-from continuity.operators.integralkernel import NaiveIntegralKernel, NeuralNetworkKernel
 
 
 class NeuralOperator(Operator):
@@ -22,42 +22,34 @@ class NeuralOperator(Operator):
 
     For now, sensor positions are equal across all layers.
 
-    TODO: This implementation has to be generalized to arbitrary `Operator` layers.
-
     Args:
-        coordinate_dim: Dimension of coordinate space
-        num_channels: Number of channels
-        depth: Number of hidden layers
-        kernel_width: Width of kernel network
-        kernel_depth: Depth of kernel network
+        shapes: Shapes of the input and output data.
+        layers: List of operator layers. First layer is used as lifting,
+                last layer as projection operator.
+        act: Activation function. Default is tanh.
     """
 
     def __init__(
         self,
         shapes: DatasetShapes,
-        depth: int = 1,
-        kernel_width: int = 32,
-        kernel_depth: int = 3,
+        layers: List[Operator],
+        act: Optional[torch.nn.Module] = None,
     ):
         super().__init__()
 
+        # Check shapes
+        assert len(layers) >= 2
+        assert layers[0].shapes.x == shapes.x
+        assert layers[0].shapes.u == shapes.u
+        for i in range(1, len(layers)):
+            assert layers[i].shapes.x == layers[i - 1].shapes.y
+            assert layers[i].shapes.u == layers[i - 1].shapes.v
+        assert layers[-1].shapes.y == shapes.y
+        assert layers[-1].shapes.v == shapes.v
+
         self.shapes = shapes
-        self.lifting = NaiveIntegralKernel(
-            NeuralNetworkKernel(shapes, kernel_width, kernel_depth),
-        )
-
-        self.hidden_layers = torch.nn.ModuleList(
-            [
-                NaiveIntegralKernel(
-                    NeuralNetworkKernel(shapes, kernel_width, kernel_depth),
-                )
-                for _ in range(depth)
-            ]
-        )
-
-        self.projection = NaiveIntegralKernel(
-            NeuralNetworkKernel(shapes, kernel_width, kernel_depth),
-        )
+        self.layers = torch.nn.ModuleList(layers)
+        self.act = act or torch.nn.Tanh()
 
     def forward(
         self, x: torch.Tensor, u: torch.Tensor, y: torch.Tensor
@@ -72,20 +64,17 @@ class NeuralOperator(Operator):
         Returns:
             Evaluations of the mapped function with shape (batch_size, y_size, num_channels)
         """
-        # Lifting layer (we use x as evaluation coordinates for now)
-        v = self.lifting(x, u, x)
-        assert v.shape[1:] == torch.Size([self.shapes.x.num, self.shapes.u.dim])
+        assert u.shape[1:] == torch.Size([self.shapes.u.num, self.shapes.u.dim])
+
+        # Lifting
+        v = self.layers[0](x, u, x)
 
         # Hidden layers
-        for layer in self.hidden_layers:
-            # Layer operation (with residual connection)
-            v = layer(x, v, x) + v
-            assert v.shape[1:] == torch.Size([self.shapes.x.num, self.shapes.u.dim])
+        for layer in self.layers[1:-1]:
+            v = self.act(layer(x, v, x)) + v
 
-            # Activation
-            v = torch.tanh(v)
+        # Projection
+        w = self.layers[-1](x, v, y)
 
-        # Projection layer
-        w = self.projection(x, v, y)
-        assert w.shape[1:] == torch.Size([y.size(1), self.shapes.u.dim])
+        assert w.shape[1:] == torch.Size([y.size(1), self.shapes.v.dim])
         return w

--- a/src/continuity/operators/shape.py
+++ b/src/continuity/operators/shape.py
@@ -1,5 +1,5 @@
 """
-`continuity.data.shape`
+`continuity.operators.shape`
 """
 
 from dataclasses import dataclass
@@ -12,11 +12,10 @@ class TensorShape:
 
 
 @dataclass
-class DatasetShapes:
-    """Shapes of all elements inside an OperatorDataset.
+class OperatorShapes:
+    """Shape of input and output functions of an Operator.
 
     Attributes:
-        num_observations: Total number of all observations in the dataset.
         x: Sensor locations.
         u: Input function evaluated at sensor locations.
         y: Evaluation locations.
@@ -24,7 +23,6 @@ class DatasetShapes:
 
     """
 
-    num_observations: int
     x: TensorShape
     u: TensorShape
     y: TensorShape

--- a/tests/data/function/test_function_dataset.py
+++ b/tests/data/function/test_function_dataset.py
@@ -39,7 +39,6 @@ def test_correct_shapes(x2_set):
     assert shapes.y.num == 13
     assert shapes.v.dim == 1
     assert shapes.v.num == 13
-    assert shapes.num_observations == 7
 
 
 def test_generate_in_distribution_observation_repr(x2_set):

--- a/tests/operators/test_integralkernel.py
+++ b/tests/operators/test_integralkernel.py
@@ -1,6 +1,6 @@
 import torch
 from continuity.benchmarks.sine import SineBenchmark
-from continuity.data.shape import DatasetShapes, TensorShape
+from continuity.operators.shape import OperatorShapes, TensorShape
 from continuity.operators.integralkernel import NeuralNetworkKernel, NaiveIntegralKernel
 
 
@@ -13,8 +13,7 @@ def test_neuralnetworkkernel():
     x = torch.rand(n_obs, x_num, x_dim)
     y = torch.rand(n_obs, y_num, y_dim)
 
-    shapes = DatasetShapes(
-        num_observations=n_obs,
+    shapes = OperatorShapes(
         x=TensorShape(num=x_num, dim=x_dim),
         u=TensorShape(num=x_num, dim=u_dim),
         y=TensorShape(num=y_num, dim=y_dim),

--- a/tests/operators/test_neuraloperator.py
+++ b/tests/operators/test_neuraloperator.py
@@ -1,5 +1,5 @@
 import pytest
-from continuity.data.shape import TensorShape, DatasetShapes
+from continuity.operators.shape import TensorShape, OperatorShapes
 from continuity.benchmarks.sine import SineBenchmark
 from continuity.operators.integralkernel import NaiveIntegralKernel, NeuralNetworkKernel
 from continuity.operators import NeuralOperator
@@ -11,24 +11,21 @@ from continuity.operators.losses import MSELoss
 def test_neuraloperator():
     # Data set
     dataset = SineBenchmark(n_train=1).train_dataset
-
     shapes = dataset.shapes
-    obs = shapes.num_observations
 
-    latent_channels = 3
-    x1 = x2 = shapes.x
-    u1 = TensorShape(shapes.u.num, latent_channels)
-    u2 = TensorShape(shapes.u.num, latent_channels)
+    latent_channels = 1
+    hidden_shape = TensorShape(shapes.u.num, latent_channels)
 
     shapes = [
-        DatasetShapes(obs, x=shapes.x, u=shapes.u, y=x1, v=u1),
-        DatasetShapes(obs, x=x1, u=u1, y=x2, v=u2),
-        DatasetShapes(obs, x=x2, u=u2, y=shapes.y, v=shapes.v),
+        OperatorShapes(x=shapes.x, u=shapes.u, y=shapes.x, v=hidden_shape),
+        OperatorShapes(x=shapes.x, u=hidden_shape, y=shapes.x, v=hidden_shape),
+        OperatorShapes(x=shapes.x, u=hidden_shape, y=shapes.y, v=shapes.v),
     ]
 
     # Operator
     layers = [
-        NaiveIntegralKernel(NeuralNetworkKernel(shapes[i], 32, 3)) for i in range(3)
+        NaiveIntegralKernel(NeuralNetworkKernel(shapes[i], 32, 3))
+        for i in range(len(shapes))
     ]
     operator = NeuralOperator(dataset.shapes, layers)
 

--- a/tests/operators/test_neuraloperator.py
+++ b/tests/operators/test_neuraloperator.py
@@ -1,6 +1,7 @@
 import pytest
-import torch
+from continuity.data.shape import TensorShape, DatasetShapes
 from continuity.benchmarks.sine import SineBenchmark
+from continuity.operators.integralkernel import NaiveIntegralKernel, NeuralNetworkKernel
 from continuity.operators import NeuralOperator
 from continuity.trainer import Trainer
 from continuity.operators.losses import MSELoss
@@ -11,17 +12,28 @@ def test_neuraloperator():
     # Data set
     dataset = SineBenchmark(n_train=1).train_dataset
 
+    shapes = dataset.shapes
+    obs = shapes.num_observations
+
+    latent_channels = 3
+    x1 = x2 = shapes.x
+    u1 = TensorShape(shapes.u.num, latent_channels)
+    u2 = TensorShape(shapes.u.num, latent_channels)
+
+    shapes = [
+        DatasetShapes(obs, x=shapes.x, u=shapes.u, y=x1, v=u1),
+        DatasetShapes(obs, x=x1, u=u1, y=x2, v=u2),
+        DatasetShapes(obs, x=x2, u=u2, y=shapes.y, v=shapes.v),
+    ]
+
     # Operator
-    operator = NeuralOperator(
-        shapes=dataset.shapes,
-        depth=1,
-        kernel_width=32,
-        kernel_depth=3,
-    )
+    layers = [
+        NaiveIntegralKernel(NeuralNetworkKernel(shapes[i], 32, 3)) for i in range(3)
+    ]
+    operator = NeuralOperator(dataset.shapes, layers)
 
     # Train
-    optimizer = torch.optim.Adam(operator.parameters(), lr=1e-2)
-    Trainer(operator, optimizer).fit(dataset, tol=1e-3)
+    Trainer(operator).fit(dataset, tol=1e-3)
 
     # Check solution
     x, u = dataset.x, dataset.u


### PR DESCRIPTION
#Cleanup: Generalize neural operator and introduce OperatorShapes

## Description

### Which issue does this PR tackle?

  - NeuralOperator hard codes integral kernel operation.
  - Fixes #96 and #55

### How does it solve the problem?

  - NeuralOperator now takes a list of operators as layers.
  - DatasetShapes is replaced by OperatorShapes.

### How are the changes tested?

  - Adopted test_neuraloperator.
  - Fix all other occurrences of DatasetShapes.


## Checklist for Contributors

- [x] Scope: This PR tackles exactly one problem.
- [x] Conventions: The branch follows the `feature/title-slug` convention.
- [x] Conventions: The PR title follows the `Bugfix: Title` convention.
- [x] Coding style: The code passes all pre-commit hooks.
- [x] Documentation: All changes are well-documented.
- [x] Tests: New features are tested and all tests pass successfully.
- [x] Changelog: Updated CHANGELOG.md for new features or breaking changes.
- [x] Review: A suitable reviewer has been assigned.


## Checklist for Reviewers:

- [x] The PR solves the issue it claims to solve and only this one.
- [x] Changes are tested sufficiently and all tests pass.
- [x] Documentation is complete and well-written.
- [x] Changelog has been updated, if necessary.
