### PR TITLE
Feature: Required package version requirements lock major

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 - Implement `DeepNeuralOperator`.
 - Generalize `NeuralOperator` to take a list of operators.
 - The `data.DatasetShapes` class becomes `operators.OperatorShapes` without `num_observations` attribute.
+- Change `torch` dependency from "==2.1.0" to ">=2.1.0,<3.0.0".
+- Change `dataptation` dependency from "==3.1" to ">=3.1,<4.0".
+- Change `optuna` dependency from "3.5.0" to ">=3.5.0,<4.0.0".
 
 ## 0.0.0 (2024-02-22)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,11 @@ dependencies = [
     # dvc               # data version control
 
     # --------- dependencies --------- #
-    "torch==2.1.0",
-    "dadaptation==3.1",
+    "torch>=2.1.0,<3.0.0",
+    "dadaptation>=3.1,<4.0",
     "matplotlib",
     "pandas",
-    "optuna==3.5.0",
+    "optuna>=3.5.0,<4.0.0",
     "numpy",
 ]
 


### PR DESCRIPTION
# Feature: Required package version requirements lock major

## Description

This PR updates the version requirements from a fixed version to a more flexible, yet controlled, version range for required packages. Namely:

- torch "==2.1.0" -> ">=2.1.0,<3.0.0"
- dataptation "==3.1" -> ">=3.1,<4.0"
- optuna "==3.5.0" -> ">=3.5.0,<4.0.0"

This change aims to balance the need for adaptability with our ability to test this package reliably.

### Which issue does this PR tackle?

  - Rocm accelerated torch is not provided for version 2.1.0.
  - Torch deletes cuda dependencies for version 2.1.0 with Poetry (even when Continuity is used as a dependency).
  - It is discuraged to use "overly strict" dependency versions when a package is used as a library [[setuptools](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html)]. And I think this should be the goal of this project.

### How does it solve the problem?

- Adapts versions of packages:
  - torch "==2.1.0" -> ">=2.1.0,<3.0.0"
  - dataptation "==3.1" -> ">=3.1,<4.0"
  - optuna "==3.5.0" -> ">=3.5.0,<4.0.0"

### How are the changes tested?

  - Unit tests run without new errors.


## Checklist for Contributors

- [x] Scope: This PR tackles exactly one problem.
- [x] Conventions: The branch follows the `feature/title-slug` convention.
- [x] Conventions: The PR title follows the `Bugfix: Title` convention.
- [x] Coding style: The code passes all pre-commit hooks.
- [x] Documentation: All changes are well-documented.
- [x] Tests: New features are tested and all tests pass successfully.
- [x] Changelog: Updated CHANGELOG.md for new features or breaking changes.
- [x] Review: A suitable reviewer has been assigned.


## Checklist for Reviewers:

- [ ] The PR solves the issue it claims to solve and only this one.
- [ ] Changes are tested sufficiently and all tests pass.
- [ ] Documentation is complete and well-written.
- [ ] Changelog has been updated, if necessary.
