### PR TITLE
Bugfix: Use last layer to evaluate.

### DIFF
--- a/tests/operators/test_neuraloperator.py
+++ b/tests/operators/test_neuraloperator.py
@@ -18,7 +18,7 @@ def test_neuraloperator():
     latent_shape = OperatorShapes(
         x=shapes.x,
         u=TensorShape(shapes.u.num, width),
-        y=shapes.x,
+        y=shapes.y,
         v=TensorShape(shapes.u.num, width),
     )
     layers = [


### PR DESCRIPTION
# Bugfix: Use last layer to evaluate.

## Description

### Which issue does this PR tackle?

  - NeuralOperator doesn't use y

### How does it solve the problem?

  - Use last layer to evaluate in y.

### How are the changes tested?

  - Tested using operator shapes test.
