### PR TITLE
Bugfix: CI venv cache ID

### DIFF
--- a/.github/actions/setup-venv/action.yml
+++ b/.github/actions/setup-venv/action.yml
@@ -20,12 +20,18 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
+    - name: Cache ID
+      shell: bash
+      run: |
+        RAW_ID="${{ runner.os }}-${{ inputs.python-version }}-venv-${{ hashFiles('pyproject.toml') }}-${{ inputs.optional-dependencies }}"
+        PROCESSED_ID=$(echo $RAW_ID | tr -d '[],')
+        echo "CACHE_ID=$PROCESSED_ID" >> $GITHUB_ENV
     - name: Cache venv
       uses: actions/cache@v4
       id: cache-venv
       with:
         path: .venv
-        key: ${{ runner.os }}-${{ matrix.python-version }}-venv-${{ hashFiles('pyproject.toml') }}-${{ inputs.optional-dependencies }}
+        key: ${{ env.CACHE_ID }}
     - name: Setup venv
       shell: bash
       run: |


### PR DESCRIPTION
# Bugfix: CI venv cache ID

## Description

This pr fixes minor issues with the CI venve cache id string.

### Which issue does this PR tackle?

  - When multiple optional dependencies are provided the venv caching does not work anymore as the string-id does not allow for ',' characters inside it.
  - The python version was not used from the input and the value was not used.

### How does it solve the problem?

  - Introduces step to cleanup the raw ID by removing '[],' characters from the raw ID.
  - Uses `inputs.python-version` instead of `matrix.python-version`.
 
### How are the changes tested?

  - CI runs without any new errors.


## Checklist for Contributors

- [x] Scope: This PR tackles exactly one problem.
- [x] Conventions: The branch follows the `feature/title-slug` convention.
- [x] Conventions: The PR title follows the `Bugfix: Title` convention.
- [x] Coding style: The code passes all pre-commit hooks.
- [x] Documentation: All changes are well-documented.
- [x] Tests: New features are tested and all tests pass successfully.
- [x] Changelog: Updated CHANGELOG.md for new features or breaking changes.
- [x] Review: A suitable reviewer has been assigned.


## Checklist for Reviewers:

- [x] The PR solves the issue it claims to solve and only this one.
- [x] Changes are tested sufficiently and all tests pass.
- [x] Documentation is complete and well-written.
- [x] Changelog has been updated, if necessary.
