### PR TITLE
Hotfix: CI pipeline venv

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,10 +19,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.11
-      - name: Setup venv
-        uses: ./.github/actions/setup-venv
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
-          os-name: ubuntu-latest
-          optional-dependencies: "[docs]"
+          cache: "pip"
+      - name: Install
+        run: |
+          pip install ".[docs]"
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,12 +26,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: "true"
-      - name: Setup venv
-        uses: ./.github/actions/setup-venv
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          os-name: ${{ matrix.os }}
-          optional-dependencies: "[testing]"
+          cache: "pip"
+      - name: Install
+        run: |
+          pip install ".[testing]"
       - name: Run pytest
         run: |
           pytest -v
@@ -52,12 +54,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: "true"
-      - name: Setup venv
-        uses: ./.github/actions/setup-venv
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          os-name: ${{ matrix.os }}
-          optional-dependencies: "[testing]"
+          cache: "pip"
+      - name: Install
+        run: |
+          pip install ".[testing]"
       - name: Install missing system dependencies
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
@@ -75,12 +79,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: "true"
-      - name: Setup venv
-        uses: ./.github/actions/setup-venv
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
-          os-name: "ubuntu-latest"
-          optional-dependencies: "[testing]"
+          python-version: 3.11
+          cache: "pip"
+      - name: Install
+        run: |
+          pip install ".[testing]"
       - name: Run tests and collect coverage
         run: pytest --cov src
       - name: Upload coverage to Codecov


### PR DESCRIPTION
# Hotfix: CI pipeline venv

## Description

This pr removes the `setup-venv` action from the CI pipelines due to an error with caching.

### Which issue does this PR tackle?

  - Currently Python versions 3.9 and 3.10 are not properly setup on MacOS (confirmed on these ones). The venv is pulled from cache but does not contain the correct dependencies.

### How does it solve the problem?

  - Changes pipelines to not use the `setup-venv` action.
  - Uses cached pip dependencies instead.

### How are the changes tested?

  - The pipeline now runs without issues.


## Checklist for Contributors

- [x] Scope: This PR tackles exactly one problem.
- [x] Conventions: The branch follows the `feature/title-slug` convention.
- [x] Conventions: The PR title follows the `Bugfix: Title` convention.
- [x] Coding style: The code passes all pre-commit hooks.
- [x] Documentation: All changes are well-documented.
- [x] Tests: New features are tested and all tests pass successfully.
- [x] Changelog: Updated CHANGELOG.md for new features or breaking changes.
- [x] Review: A suitable reviewer has been assigned.


## Checklist for Reviewers:

- [x] The PR solves the issue it claims to solve and only this one.
- [x] Changes are tested sufficiently and all tests pass.
- [x] Documentation is complete and well-written.
- [x] Changelog has been updated, if necessary.
