### PR TITLE
Make Trainer usable with standard torch model.

### DIFF
--- a/src/continuity/trainer/callbacks.py
+++ b/src/continuity/trainer/callbacks.py
@@ -60,14 +60,13 @@ class PrintTrainingLoss(Callback):
         self.start_time = time()
         super().__init__()
 
-    def step(self, logs: Logs):
-        """Called after every gradient step.
+    def __call__(self, logs: Logs):
+        """Callback function.
+        Called at the end of each epoch.
 
         Args:
             logs: Training logs.
         """
-        self.steps_performed += 1
-
         elapsed = time() - self.start_time
         sec_per_step = elapsed / self.steps_performed
 
@@ -112,6 +111,15 @@ class PrintTrainingLoss(Callback):
             s += f"loss/test = {logs.loss_test:.4e} "
 
         print("\r" + s, end="")
+
+    def step(self, logs: Logs):
+        """Called after every gradient step.
+
+        Args:
+            logs: Training logs.
+        """
+        self.steps_performed += 1
+        self.__call__(logs)
 
     def on_train_begin(self):
         """Called at the beginning of training."""


### PR DESCRIPTION
# Feature: Make Trainer usable with standard torch model.

## Description

### Which issue does this PR tackle?

  - Trainer is a general training loop implementation, but does not work with standard torch models.

### How does it solve the problem?

  - Adapts only a few lines in `Trainer.fit` such that we can also train torch models with it.
  - Fixes the PrintTrainingLoss to print the current test loss (which is also used for stopping criterion).

### How are the changes tested?

  - Added test_trainer_with_torch_model.


## Checklist for Contributors

- [x] Scope: This PR tackles exactly one problem.
- [x] Conventions: The branch follows the `feature/title-slug` convention.
- [x] Conventions: The PR title follows the `Bugfix: Title` convention.
- [x] Coding style: The code passes all pre-commit hooks.
- [x] Documentation: All changes are well-documented.
- [x] Tests: New features are tested and all tests pass successfully.
- [x] Changelog: Updated CHANGELOG.md for new features or breaking changes.
- [x] Review: A suitable reviewer has been assigned.


## Checklist for Reviewers:

- [x] The PR solves the issue it claims to solve and only this one.
- [x] Changes are tested sufficiently and all tests pass.
- [x] Documentation is complete and well-written.
- [x] Changelog has been updated, if necessary.
