### PR TITLE
Fix: Transformations Not Properly Working When Moved to Device

### DIFF
--- a/src/continuity/transforms/scaling.py
+++ b/src/continuity/transforms/scaling.py
@@ -3,6 +3,7 @@
 """
 
 import torch
+import torch.nn as nn
 from .transform import Transform
 
 
@@ -28,8 +29,8 @@ class Normalize(Transform):
 
     def __init__(self, mean: torch.Tensor, std: torch.Tensor):
         super().__init__()
-        self.mean = mean
-        self.std = std
+        self.mean = nn.Parameter(mean)
+        self.std = nn.Parameter(std)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         r"""Apply normalization to the input tensor.


### PR DESCRIPTION
# Fix: Transformations Not Properly Working When Moved to Device

## Description

This pr introduces the torch tensor class `Parameter` to Transform classes. When moving `nn.Module` instances to device it only moves designated parameters to the device. Common `torch.Tensor` instances do not belong to this class. `torch.nn.Parameter` fixes this issue.

### Which issue does this PR tackle?

  - Transform instances parameters not moved to device.
  - Fixes #117

### How does it solve the problem?

  - Introduces `nn.Parameter` tensors to already implemented transformations (for relevant attributes).

### How are the changes tested?

  - Unit tests run without new errors.
  - Ran locally on `cuda`.


## Checklist for Contributors

- [x] Scope: This PR tackles exactly one problem.
- [x] Conventions: The branch follows the `feature/title-slug` convention.
- [x] Conventions: The PR title follows the `Bugfix: Title` convention.
- [x] Coding style: The code passes all pre-commit hooks.
- [x] Documentation: All changes are well-documented.
- [x] Tests: New features are tested and all tests pass successfully.
- [x] Changelog: Updated CHANGELOG.md for new features or breaking changes.
- [x] Review: A suitable reviewer has been assigned.


## Checklist for Reviewers:

- [ ] The PR solves the issue it claims to solve and only this one.
- [ ] Changes are tested sufficiently and all tests pass.
- [ ] Documentation is complete and well-written.
- [ ] Changelog has been updated, if necessary.
